### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v8
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/grzegorz914/homebridge-openwebif-tv/security/code-scanning/1](https://github.com/grzegorz914/homebridge-openwebif-tv/security/code-scanning/1)

In general, to fix this class of problem you should explicitly declare a `permissions` block in the workflow or in each job, granting only the scopes actually required. This avoids falling back to potentially broad repository/organization defaults and documents the permissions that the workflow needs.

For this specific workflow, the `stale` job uses `actions/stale@v8` to mark and close issues and pull requests, which requires write access to `issues` and `pull-requests`. It does not need to modify repository contents. The minimal, least‑privilege configuration therefore should grant `contents: read` (safe default) and `issues: write` and `pull-requests: write`. The CodeQL suggestion of `contents: write` is broader than necessary here, since the stale bot does not change files in the repo. The best fix is to add a `permissions` block scoped to the `stale` job, right under `runs-on: ubuntu-latest`, so that only this job gets the required rights and existing behavior (closing and commenting on issues/PRs) continues to work.

Concretely:
- Edit `.github/workflows/stale.yml`.
- Under `jobs: stale: runs-on: ubuntu-latest`, add:
  ```yaml
      permissions:
        contents: read
        issues: write
        pull-requests: write
  ```
- No imports or additional definitions are needed since this is a YAML workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
